### PR TITLE
Throw exception for errors that are returned along with an "ok" http status

### DIFF
--- a/src/Rest.php
+++ b/src/Rest.php
@@ -52,27 +52,26 @@ class Rest
      * @param string $result   The API response
      * @param int    $httpCode The HTTP status code
      *
-     * @throws Exception
+     * @throws ClickatellException
      * @return array
      */
     protected function handle($result, $httpCode)
     {
-        // Check for non-OK statuses
+        $decoded = json_decode($result, true);
+
+        // Check for OK statuses
         $codes = explode(",", static::ACCEPTED_CODES);
+        $ok_status = in_array($httpCode, $codes);
 
-        if (!in_array($httpCode, $codes)) {
-            // Decode JSON if possible, if this can't be decoded...something fatal went wrong
-            // and we will just return the entire body as an exception.
-            if ($error = json_decode($result, true)) {
-                $error = $error['error'];
-            } else {
-                $error = $result;
-            }
+        $is_error = isset($decoded['error']) || !$ok_status;
+        if ($is_error) {
+            // If no error key is present in the decoded JSON, return the entire body as an exception.
+            $error = isset($decoded['error']) ? $decoded['error'] : $result;
 
-            throw new \Clickatell\ClickatellException($error);
-        } else {
-            return json_decode($result, true);
+            throw new ClickatellException($error);
         }
+
+        return $decoded;
     }
 
     /**


### PR DESCRIPTION
If a response is returned with a 200 OK status and the decoded JSON contains an 'error' key, the library currently returns an empty array as a result.

This PR resolves this by throwing an exception if the JSON contains an error.